### PR TITLE
Harden development settings usage

### DIFF
--- a/BE-farm/DEPLOYMENT.md
+++ b/BE-farm/DEPLOYMENT.md
@@ -1,0 +1,7 @@
+# Deployment
+
+The Wagtail backend ships with multiple Django settings modules for different purposes. **Only `pig_farm_cms.settings.production` must be used for any live or customer-facing environment.**
+
+Set the `DJANGO_SETTINGS_MODULE` environment variable to `pig_farm_cms.settings.production` for production deployments and ensure the `DJANGO_ENV` environment variable is set to `production` so that development-only settings cannot be imported accidentally.
+
+Other settings modules (such as `pig_farm_cms.settings.dev`) are intended strictly for local development and require additional environment variables like `DJANGO_SECRET_KEY` to be configured when used.

--- a/BE-farm/pig_farm_cms/settings/dev.py
+++ b/BE-farm/pig_farm_cms/settings/dev.py
@@ -1,13 +1,27 @@
+import os
+
+from django.core.exceptions import ImproperlyConfigured
+
 from .base import *
+
+
+if os.environ.get("DJANGO_ENV") not in (None, "", "development"):
+    raise ImproperlyConfigured(
+        "pig_farm_cms.settings.dev should not be imported outside of a development environment."
+    )
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = "django-insecure-!08#y$wtz*b(dno8)__5kzmh^8de3n9dzv!g-z1dp*zq5n628u"
+SECRET_KEY = os.environ.get("DJANGO_SECRET_KEY")
+if not SECRET_KEY:
+    raise ImproperlyConfigured(
+        "DJANGO_SECRET_KEY must be set when using pig_farm_cms.settings.dev."
+    )
 
 # SECURITY WARNING: define the correct hosts in production!
-ALLOWED_HOSTS = ["*"]
+ALLOWED_HOSTS = ["localhost", "127.0.0.1", "[::1]"]
 
 EMAIL_BACKEND = "django.core.mail.backends.console.EmailBackend"
 


### PR DESCRIPTION
## Summary
- load the development secret key from the environment and fail fast when it is missing
- prevent development settings from being used in production by checking `DJANGO_ENV` and restricting allowed hosts
- document that only `pig_farm_cms.settings.production` should be used for live deployments

## Testing
- DJANGO_SECRET_KEY=devsecret python manage.py check

------
https://chatgpt.com/codex/tasks/task_e_68d132fa62908328aab095736ec8216f