### PR TITLE
Improve handling of large form submissions

### DIFF
--- a/BE-farm/pig_farm_cms/middleware.py
+++ b/BE-farm/pig_farm_cms/middleware.py
@@ -1,0 +1,79 @@
+"""Custom middleware for managing large form submissions."""
+
+from __future__ import annotations
+
+import logging
+from typing import Iterable
+
+from django.conf import settings
+from django.core.exceptions import TooManyFieldsSent
+from django.http import HttpResponseForbidden
+
+
+class LargeFormSubmissionControlMiddleware:
+    """Log and restrict unusually large form submissions.
+
+    Django applies :setting:`DATA_UPLOAD_MAX_NUMBER_FIELDS` globally, which means that
+    increasing it to support the Wagtail admin also affects anonymous endpoints. This
+    middleware adds authentication requirements for anonymous users that attempt to submit
+    very large payloads, and instruments submissions so operations teams can monitor them.
+    """
+
+    request_methods: Iterable[str] = ("POST", "PUT", "PATCH")
+
+    def __init__(self, get_response):
+        self.get_response = get_response
+        self.logger = logging.getLogger("pig_farm.security")
+
+    def __call__(self, request):
+        if request.method in self.request_methods:
+            user = getattr(request, "user", None)
+            try:
+                total_fields = self._count_fields(request)
+            except TooManyFieldsSent:
+                self.logger.warning(
+                    "Rejected %s request to %s with too many fields (limit=%s) from %s",
+                    request.method,
+                    request.path,
+                    settings.DATA_UPLOAD_MAX_NUMBER_FIELDS,
+                    request.META.get("REMOTE_ADDR", "unknown"),
+                )
+                raise
+
+            if total_fields >= settings.LARGE_FORM_LOG_THRESHOLD:
+                self.logger.info(
+                    "Large form submission detected: %s fields on %s request to %s (authenticated=%s)",
+                    total_fields,
+                    request.method,
+                    request.path,
+                    getattr(user, "is_authenticated", False),
+                )
+
+            if (
+                total_fields > settings.ANONYMOUS_MAX_FORM_FIELDS
+                and not getattr(user, "is_authenticated", False)
+                and self._is_protected_path(request.path)
+            ):
+                self.logger.warning(
+                    "Blocked anonymous large form submission: %s fields on %s request to %s from %s",
+                    total_fields,
+                    request.method,
+                    request.path,
+                    request.META.get("REMOTE_ADDR", "unknown"),
+                )
+                return HttpResponseForbidden("Too many form fields submitted.")
+
+        response = self.get_response(request)
+        return response
+
+    @staticmethod
+    def _is_protected_path(path: str) -> bool:
+        return any(
+            path.startswith(prefix) for prefix in settings.LARGE_FORM_PROTECTED_PATH_PREFIXES
+        )
+
+    @staticmethod
+    def _count_fields(request) -> int:
+        post_field_count = sum(len(values) for _, values in request.POST.lists())
+        file_field_count = sum(len(values) for _, values in request.FILES.lists())
+        return post_field_count + file_field_count

--- a/BE-farm/pig_farm_cms/settings/base.py
+++ b/BE-farm/pig_farm_cms/settings/base.py
@@ -13,6 +13,13 @@ https://docs.djangoproject.com/en/5.2/ref/settings/
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 import os
 
+
+def _env_int(setting_name: str, default: int) -> int:
+    try:
+        return int(os.environ.get(setting_name, default))
+    except (TypeError, ValueError):
+        return int(default)
+
 PROJECT_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 BASE_DIR = os.path.dirname(PROJECT_DIR)
 
@@ -54,6 +61,7 @@ MIDDLEWARE = [
     "django.middleware.common.CommonMiddleware",
     "django.middleware.csrf.CsrfViewMiddleware",
     "django.contrib.auth.middleware.AuthenticationMiddleware",
+    "pig_farm_cms.middleware.LargeFormSubmissionControlMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
     "wagtail.contrib.redirects.middleware.RedirectMiddleware",
@@ -153,9 +161,42 @@ STORAGES = {
     },
 }
 
-# Django sets a maximum of 1000 fields per form by default, but particularly complex page models
-# can exceed this limit within Wagtail's page editor.
-DATA_UPLOAD_MAX_NUMBER_FIELDS = 10_000
+# Django sets a maximum of 1000 fields per form by default. Our current Wagtail page
+# implementations are considerably smaller than that value, but we still provide headroom
+# for future growth via configuration.
+DATA_UPLOAD_MAX_NUMBER_FIELDS = max(1, _env_int("DATA_UPLOAD_MAX_NUMBER_FIELDS", 2_000))
+
+# Requests that submit more than this number of fields must already be authenticated when
+# they target protected endpoints. This prevents anonymous users from leveraging the higher
+# global limit for abuse.
+ANONYMOUS_MAX_FORM_FIELDS = _env_int("ANONYMOUS_MAX_FORM_FIELDS", 500)
+ANONYMOUS_MAX_FORM_FIELDS = max(
+    0,
+    min(ANONYMOUS_MAX_FORM_FIELDS, DATA_UPLOAD_MAX_NUMBER_FIELDS),
+)
+
+_default_log_threshold = max(
+    ANONYMOUS_MAX_FORM_FIELDS,
+    int(DATA_UPLOAD_MAX_NUMBER_FIELDS * 0.75),
+)
+_default_log_threshold = min(_default_log_threshold, DATA_UPLOAD_MAX_NUMBER_FIELDS)
+
+# Large submissions that stay within the allowed limits are still logged so that operations
+# teams can monitor for suspicious spikes.
+LARGE_FORM_LOG_THRESHOLD = max(
+    1,
+    min(_env_int("LARGE_FORM_LOG_THRESHOLD", _default_log_threshold), DATA_UPLOAD_MAX_NUMBER_FIELDS),
+)
+
+_protected_prefixes_env = os.environ.get(
+    "LARGE_FORM_PROTECTED_PATH_PREFIXES",
+    "/admin/,/django-admin/",
+)
+LARGE_FORM_PROTECTED_PATH_PREFIXES = tuple(
+    prefix.strip()
+    for prefix in _protected_prefixes_env.split(",")
+    if prefix.strip()
+)
 
 
 # Wagtail settings
@@ -179,3 +220,25 @@ WAGTAILADMIN_BASE_URL = "http://example.com"
 # if untrusted users are allowed to upload files -
 # see https://docs.wagtail.org/en/stable/advanced_topics/deploying.html#user-uploaded-files
 WAGTAILDOCS_EXTENSIONS = ['csv', 'docx', 'key', 'odt', 'pdf', 'pptx', 'rtf', 'txt', 'xlsx', 'zip']
+
+
+LOGGING = {
+    "version": 1,
+    "disable_existing_loggers": False,
+    "handlers": {
+        "console": {
+            "class": "logging.StreamHandler",
+        },
+    },
+    "loggers": {
+        "pig_farm.security": {
+            "handlers": ["console"],
+            "level": os.environ.get("PIG_FARM_SECURITY_LOG_LEVEL", "INFO"),
+        },
+        "django.security.SuspiciousOperation": {
+            "handlers": ["console"],
+            "level": "WARNING",
+            "propagate": False,
+        },
+    },
+}

--- a/BE-farm/pig_farm_cms/tests/test_large_form_middleware.py
+++ b/BE-farm/pig_farm_cms/tests/test_large_form_middleware.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from django.conf import settings
+from django.contrib.auth import get_user_model
+from django.core.exceptions import TooManyFieldsSent
+from django.test import TestCase, override_settings
+
+
+@override_settings(
+    ROOT_URLCONF="pig_farm_cms.tests.urls",
+    DATA_UPLOAD_MAX_NUMBER_FIELDS=200,
+    ANONYMOUS_MAX_FORM_FIELDS=20,
+    LARGE_FORM_LOG_THRESHOLD=50,
+    LARGE_FORM_PROTECTED_PATH_PREFIXES=("/admin/",),
+)
+class LargeFormMiddlewareTests(TestCase):
+    def _build_payload(self, field_count: int) -> dict[str, str]:
+        return {f"field_{index}": "value" for index in range(field_count)}
+
+    def test_blocks_anonymous_large_admin_submission(self):
+        payload = self._build_payload(settings.ANONYMOUS_MAX_FORM_FIELDS + 1)
+        response = self.client.post("/admin/test/", data=payload)
+        self.assertEqual(response.status_code, 403)
+
+    def test_allows_authenticated_large_submission(self):
+        user_model = get_user_model()
+        user = user_model.objects.create_user(
+            username="editor",
+            email="editor@example.com",
+            password="test-pass-123",
+            is_staff=True,
+        )
+        self.client.force_login(user)
+
+        payload = self._build_payload(settings.ANONYMOUS_MAX_FORM_FIELDS + 5)
+        response = self.client.post("/admin/test/", data=payload)
+        self.assertEqual(response.status_code, 200)
+
+    def test_logs_when_threshold_reached(self):
+        user_model = get_user_model()
+        user = user_model.objects.create_user(
+            username="logger",
+            email="logger@example.com",
+            password="test-pass-123",
+            is_staff=True,
+        )
+        self.client.force_login(user)
+
+        payload = self._build_payload(settings.LARGE_FORM_LOG_THRESHOLD)
+        with self.assertLogs("pig_farm.security", level="INFO") as logs:
+            response = self.client.post("/admin/test/", data=payload)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(
+            any("Large form submission detected" in message for message in logs.output),
+            msg="Expected info log when large form threshold is reached.",
+        )
+
+    def test_logs_when_limit_is_exceeded(self):
+        payload = self._build_payload(15)
+        from pig_farm_cms.middleware import LargeFormSubmissionControlMiddleware
+
+        with patch.object(
+            LargeFormSubmissionControlMiddleware,
+            "_count_fields",
+            side_effect=TooManyFieldsSent("test"),
+        ):
+            with self.assertLogs("pig_farm.security", level="WARNING") as logs:
+                response = self.client.post("/admin/test/", data=payload)
+
+        self.assertEqual(response.status_code, 400)
+
+        self.assertTrue(
+            any("with too many fields" in message for message in logs.output),
+            msg="Expected warning log when the upload limit is exceeded.",
+        )

--- a/BE-farm/pig_farm_cms/tests/urls.py
+++ b/BE-farm/pig_farm_cms/tests/urls.py
@@ -1,0 +1,13 @@
+from django.http import HttpResponse
+from django.urls import path
+
+
+def admin_echo_view(request):
+    """Simple view used for exercising middleware behaviour in tests."""
+
+    return HttpResponse("ok")
+
+
+urlpatterns = [
+    path("admin/test/", admin_echo_view, name="middleware-test-admin"),
+]


### PR DESCRIPTION
## Summary
- make the maximum number of accepted form fields configurable with safer defaults and supporting settings for logging and protected paths
- add middleware that enforces authentication for very large submissions on administrative endpoints while logging unusually large payloads
- configure security-focused logging and add regression tests covering the middleware behaviours

## Testing
- `python manage.py test` *(fails: existing `home.tests.HomeTests` expect a `home` URL that is not defined in the project)*
- `python manage.py test pig_farm_cms.tests.test_large_form_middleware`


------
https://chatgpt.com/codex/tasks/task_e_68d13719944c8328abe7fd1062671f2a